### PR TITLE
Enable soaring type setpoints

### DIFF
--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -10,6 +10,7 @@ uint8 SETPOINT_TYPE_LAND=4	# land setpoint, altitude must be ignored, descend un
 uint8 SETPOINT_TYPE_IDLE=5	# do nothing, switch off motors or keep at idle speed (MC)
 uint8 SETPOINT_TYPE_OFFBOARD=6 	# setpoint in NED frame (x, y, z, vx, vy, vz) set by offboard
 uint8 SETPOINT_TYPE_FOLLOW_TARGET=7  # setpoint in NED frame (x, y, z, vx, vy, vz) set by follow target
+uint8 SETPOINT_TYPE_SOARING=8 #setpoint in NED frame with zero throttle (FW)
 
 uint8 VELOCITY_FRAME_LOCAL_NED = 1 # MAV_FRAME_LOCAL_NED
 uint8 VELOCITY_FRAME_BODY_NED = 8 # MAV_FRAME_BODY_NED

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -867,7 +867,8 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 						   false,
 						   radians(_parameters.pitch_limit_min));
 
-		} else if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
+		} else if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_LOITER
+			   || pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_SOARING) {
 
 			/* waypoint is a loiter waypoint */
 			float loiter_radius = pos_sp_curr.loiter_radius;
@@ -1140,6 +1141,10 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 
 	} else if (_control_mode_current == FW_POSCTRL_MODE_OTHER) {
 		_att_sp.thrust_body[0] = min(_att_sp.thrust_body[0], _parameters.throttle_max);
+
+	} else if (_control_mode_current == FW_POSCTRL_MODE_AUTO &&
+		   pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_SOARING) {
+		_att_sp.thrust_body[0] = 0.0f;
 
 	} else {
 		/* Copy thrust and pitch values from tecs */

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -98,6 +98,7 @@ FixedwingPositionControl::FixedwingPositionControl() :
 	_parameter_handles.heightrate_p = param_find("FW_T_HRATE_P");
 	_parameter_handles.heightrate_ff = param_find("FW_T_HRATE_FF");
 	_parameter_handles.speedrate_p = param_find("FW_T_SRATE_P");
+	_parameter_handles.loiter_radius = param_find("NAV_LOITER_RAD");
 
 	// if vehicle is vtol these handles will be set when we get the vehicle status
 	_parameter_handles.airspeed_trans = PARAM_INVALID;
@@ -165,6 +166,7 @@ FixedwingPositionControl::parameters_update()
 	param_get(_parameter_handles.land_early_config_change, &(_parameters.land_early_config_change));
 	param_get(_parameter_handles.land_airspeed_scale, &(_parameters.land_airspeed_scale));
 	param_get(_parameter_handles.land_throtTC_scale, &(_parameters.land_throtTC_scale));
+	param_get(_parameter_handles.loiter_radius, &(_parameters.loiter_radius));
 
 	// VTOL parameter VTOL_TYPE
 	if (_parameter_handles.vtol_type != PARAM_INVALID) {
@@ -868,8 +870,17 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 		} else if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
 
 			/* waypoint is a loiter waypoint */
-			_l1_control.navigate_loiter(curr_wp, curr_pos, pos_sp_curr.loiter_radius,
-						    pos_sp_curr.loiter_direction, nav_speed_2d);
+			float loiter_radius = pos_sp_curr.loiter_radius;
+			uint8_t loiter_direction = pos_sp_curr.loiter_direction;
+
+			if (pos_sp_curr.loiter_radius <= 0) { //TODO: Get loiter radius from parameter
+				loiter_radius = _parameters.loiter_radius;
+				loiter_direction = 1;
+
+			}
+
+			_l1_control.navigate_loiter(curr_wp, curr_pos, loiter_radius, loiter_direction, nav_speed_2d);
+
 			_att_sp.roll_body = _l1_control.get_roll_setpoint();
 			_att_sp.yaw_body = _l1_control.nav_bearing();
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -873,9 +873,9 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 			float loiter_radius = pos_sp_curr.loiter_radius;
 			uint8_t loiter_direction = pos_sp_curr.loiter_direction;
 
-			if (pos_sp_curr.loiter_radius <= 0) { //TODO: Get loiter radius from parameter
+			if (pos_sp_curr.loiter_radius < 0.01f || pos_sp_curr.loiter_radius > -0.01f) {
 				loiter_radius = _parameters.loiter_radius;
-				loiter_direction = 1;
+				loiter_direction = (loiter_radius > 0) ? 1 : -1;
 
 			}
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -295,6 +295,7 @@ private:
 		float pitchsp_offset_rad;
 
 		float throttle_land_max;
+		float loiter_radius;
 
 		float land_heading_hold_horizontal_distance;
 		float land_flare_pitch_min_deg;
@@ -368,6 +369,7 @@ private:
 		param_t land_early_config_change;
 		param_t land_airspeed_scale;
 		param_t land_throtTC_scale;
+		param_t loiter_radius;
 
 		param_t vtol_type;
 	} _parameter_handles {};				///< handles for interesting parameters */

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -773,7 +773,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 		bool is_land_sp = (bool)(set_position_target_local_ned.type_mask & 0x2000);
 		bool is_loiter_sp = (bool)(set_position_target_local_ned.type_mask & 0x3000);
 		bool is_idle_sp = (bool)(set_position_target_local_ned.type_mask & 0x4000);
-		bool is_soaring_sp = (bool)(set_position_target_local_ned.type_mask & 0x5000);
+		bool is_soaring_sp = (bool)(set_position_target_local_ned.type_mask & 0x8000);
 
 		offboard_control_mode.timestamp = hrt_absolute_time();
 		_offboard_control_mode_pub.publish(offboard_control_mode);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -773,6 +773,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 		bool is_land_sp = (bool)(set_position_target_local_ned.type_mask & 0x2000);
 		bool is_loiter_sp = (bool)(set_position_target_local_ned.type_mask & 0x3000);
 		bool is_idle_sp = (bool)(set_position_target_local_ned.type_mask & 0x4000);
+		bool is_soaring_sp = (bool)(set_position_target_local_ned.type_mask & 0x5000);
 
 		offboard_control_mode.timestamp = hrt_absolute_time();
 		_offboard_control_mode_pub.publish(offboard_control_mode);
@@ -812,6 +813,9 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 
 					} else if (is_idle_sp) {
 						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_IDLE;
+
+					} else if (is_soaring_sp) {
+						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_SOARING;
 
 					} else {
 						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;


### PR DESCRIPTION
This PR enable soaring type setpoints, which can be enabled offboard.

A new setpoint type is defined therefore the throttle can enable / disabled by switching the setpoint type. It is processed as the same as a loiter setpoint